### PR TITLE
Re-order checks for performance

### DIFF
--- a/ScanBlockPlugin/ScanBlockFeature.cs
+++ b/ScanBlockPlugin/ScanBlockFeature.cs
@@ -77,12 +77,13 @@ namespace Alstra.ScanBlockPlugin
                 return;
             }
 
-            // Request is already handled
-            if (request.Items.ContainsKey(config.RequestItemKey))
+            // If we already handled this request, skip it
+            if (IsRequestHandled(request))
             {
                 return;
             }
-            request.Items[config.RequestItemKey] = new object();
+
+            MarkRequestHandled(request);
 
             // Should we list host scores?
             if (request.PathInfo.Equals(config.HostScoreListingPath, StringComparison.OrdinalIgnoreCase)
@@ -221,5 +222,23 @@ namespace Alstra.ScanBlockPlugin
                 config.HostScoreInfoFormatter.MimeType).Wait();
             response.EndRequest();
         }
+
+        /// <summary>
+        /// Determines whether the specified request has been handled.
+        /// </summary>
+        /// <param name="request">The request to check.</param>
+        /// <returns><see langword="true"/> if the request contains the required item key indicating it has been handled; 
+        /// otherwise, <see langword="false"/>.</returns>
+        private bool IsRequestHandled(IRequest request) =>
+            request.Items.ContainsKey(config.RequestItemKey);
+
+        /// <summary>
+        /// Marks the specified request as handled by associating it with a marker object.
+        /// </summary>
+        /// <remarks>This method uses the configured request item key to store a marker object in the
+        /// request's items collection.</remarks>
+        /// <param name="request">The request to mark as handled.</param>
+        private void MarkRequestHandled(IRequest request) =>
+            request.Items[config.RequestItemKey] = new object();
     }
 }

--- a/ScanBlockPlugin/ScanBlockFeature.cs
+++ b/ScanBlockPlugin/ScanBlockFeature.cs
@@ -85,16 +85,10 @@ namespace Alstra.ScanBlockPlugin
             request.Items[config.RequestItemKey] = new object();
 
             // Should we list host scores?
-                var table = HostScoreRegistry.GetScoreInfoState();
-                response.StatusCode = (int)HttpStatusCode.OK;
-                response.ContentType = config.HostScoreInfoFormatter.MimeType;
-                response.WriteToResponse(
-                    config.HostScoreInfoFormatter.Format(table, config),
-                    config.HostScoreInfoFormatter.MimeType).Wait();
-                response.EndRequest();
             if (request.PathInfo.Equals(config.HostScoreListingPath, StringComparison.OrdinalIgnoreCase)
                 && config.AllowHostScoreListing(request))
             {
+                ListHostScores(response);
                 return;
             }
 
@@ -211,6 +205,17 @@ namespace Alstra.ScanBlockPlugin
                 HostScoreRegistry.AddScore(request.RemoteIp, score, reason);
                 config.OnScoredRequest(request, reason);
             }
+        }
+
+        private void ListHostScores(IResponse response)
+        {
+            var table = HostScoreRegistry.GetScoreInfoState();
+            response.StatusCode = (int)HttpStatusCode.OK;
+            response.ContentType = config.HostScoreInfoFormatter.MimeType;
+            response.WriteToResponse(
+                config.HostScoreInfoFormatter.Format(table, config),
+                config.HostScoreInfoFormatter.MimeType).Wait();
+            response.EndRequest();
         }
     }
 }

--- a/ScanBlockPlugin/ScanBlockFeature.cs
+++ b/ScanBlockPlugin/ScanBlockFeature.cs
@@ -77,7 +77,7 @@ namespace Alstra.ScanBlockPlugin
                 return;
             }
 
-            // If we already handled this request, skip it
+            // Is this request already handled?
             if (IsRequestHandled(request))
             {
                 return;
@@ -93,13 +93,13 @@ namespace Alstra.ScanBlockPlugin
                 return;
             }
 
-            // We don't check allowed hosts
+            // Is the host permanently allowed?
             if (config.PermanentlyAllowedHosts.Contains(request.RemoteIp))
             {
                 return;
             }
 
-            // Skip scoring for this request
+            // Should we skip scoring for this request?
             if (config.SkipHostScoringForRequest(request))
             {
                 return;

--- a/ScanBlockPlugin/ScanBlockFeature.cs
+++ b/ScanBlockPlugin/ScanBlockFeature.cs
@@ -207,6 +207,10 @@ namespace Alstra.ScanBlockPlugin
             }
         }
 
+        /// <summary>
+        /// Hijack response to list host scores
+        /// </summary>
+        /// <param name="response"></param>
         private void ListHostScores(IResponse response)
         {
             var table = HostScoreRegistry.GetScoreInfoState();

--- a/ScanBlockPlugin/ScanBlockFeature.cs
+++ b/ScanBlockPlugin/ScanBlockFeature.cs
@@ -92,14 +92,14 @@ namespace Alstra.ScanBlockPlugin
                 return;
             }
 
-            // No checks on logged in users
-            if (config.SkipHostScoringForRequest(request))
+            // We don't check allowed hosts
+            if (config.PermanentlyAllowedHosts.Contains(request.RemoteIp))
             {
                 return;
             }
 
-            // We don't check allowed hosts
-            if (config.PermanentlyAllowedHosts.Contains(request.RemoteIp))
+            // Skip scoring for this request
+            if (config.SkipHostScoringForRequest(request))
             {
                 return;
             }

--- a/ScanBlockPlugin/ScanBlockFeature.cs
+++ b/ScanBlockPlugin/ScanBlockFeature.cs
@@ -85,9 +85,6 @@ namespace Alstra.ScanBlockPlugin
             request.Items[config.RequestItemKey] = new object();
 
             // Should we list host scores?
-            if (config.AllowHostScoreListing(request)
-                && request.PathInfo.Equals(config.HostScoreListingPath, StringComparison.OrdinalIgnoreCase))
-            {
                 var table = HostScoreRegistry.GetScoreInfoState();
                 response.StatusCode = (int)HttpStatusCode.OK;
                 response.ContentType = config.HostScoreInfoFormatter.MimeType;
@@ -95,6 +92,9 @@ namespace Alstra.ScanBlockPlugin
                     config.HostScoreInfoFormatter.Format(table, config),
                     config.HostScoreInfoFormatter.MimeType).Wait();
                 response.EndRequest();
+            if (request.PathInfo.Equals(config.HostScoreListingPath, StringComparison.OrdinalIgnoreCase)
+                && config.AllowHostScoreListing(request))
+            {
                 return;
             }
 


### PR DESCRIPTION
## Description

- Reorder check so that path is valid before `config.AllowHostScoreListing` is called
- Check `PermanentlyAllowedHosts` before call to `SkipHostScoringForRequest`
- Move inline code to functions
- Add docs and comments
